### PR TITLE
Small changes

### DIFF
--- a/README.org
+++ b/README.org
@@ -15,7 +15,7 @@ All the Input is internally linked to be passed into the executing program. And 
     :custom
     (comp-ide-auto-execute-on-compile t)
     :config
-    (require 'ide-mode-recipes)
+    (require 'comp-ide-recipes)
     (evil-define-key 'normal 'prog-mode-map (kbd "\\i") comp-ide-command-map) 
     (evil-define-key 'normal 'comp-ide-slave-mode-map (kbd "\\i") comp-ide-command-map)
     (evil-define-key 'normal 'prog-mode-map (kbd "\\ti") 'comp-ide)

--- a/comp-ide.el
+++ b/comp-ide.el
@@ -148,18 +148,18 @@ REPL - Replacing string"
 (defun comp-ide-comp-ide-compile()
   "Compile the code."
   (interactive)
-  (setq comp-ide-extension (nth 1 (split-string (buffer-name) "\\.")))
-  (setq comp-ide-file-name (nth 0 (split-string (buffer-name) "\\.")))
-  
+  (setq comp-ide-src (file-name-nondirectory (buffer-file-name)))
+  (setq comp-ide-extension (file-name-extension comp-ide-src))
+  (setq comp-ide-file-name (file-name-sans-extension (file-name-nondirectory (buffer-file-name))))
   (setq comp-ide-command
         (comp-ide-find-from-dict comp-ide-comp-ide-compile-recipes comp-ide-extension))
   (setq comp-ide-command
         (string-join (split-string (string-join
-                                    (split-string comp-ide-command "%bf") (buffer-name)) "%bo")
+                                    (split-string comp-ide-command "%bf") comp-ide-src) "%bo")
                      comp-ide-file-name))
 
   (save-excursion
-  (compile comp-ide-command)))
+    (compile comp-ide-command)))
 
 (defun comp-ide-comp-ide-execute()
   "Execute the code."


### PR DESCRIPTION
Fixed that the compile command did not work when multiple buffers had name with <text> somewhere, which is something that happens when buffers share the same name. Also fixed require in readme.